### PR TITLE
Cargo: update uefi crates to the released version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,8 +94,9 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.34.1"
-source = "git+https://github.com/rust-osdev/uefi-rs.git#7c33b439bb6a3e049b1c87a07bf418a1c7d24409"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7569ceafb898907ff764629bac90ac24ba4203c38c33ef79ee88c74aa35b11"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -109,8 +110,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-macros"
-version = "0.18.0"
-source = "git+https://github.com/rust-osdev/uefi-rs.git#7c33b439bb6a3e049b1c87a07bf418a1c7d24409"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3dad47b3af8f99116c0f6d4d669c439487d9aaf1c8d9480d686cda6f3a8aa23"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -119,8 +121,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-raw"
-version = "0.10.0"
-source = "git+https://github.com/rust-osdev/uefi-rs.git#7c33b439bb6a3e049b1c87a07bf418a1c7d24409"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cad96b8baaf1615d3fdd0f03d04a0b487d857c1b51b19dcbfe05e2e3c447b78"
 dependencies = [
  "bitflags",
  "uguid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,4 @@ edition = "2021"
 
 [dependencies]
 log = "0.4.25"
-#uefi = { version = "0.33.0", features = ["alloc", "global_allocator", "logger", "panic_handler"] }
-uefi = { version = "0.34.1", features = ["alloc", "global_allocator", "logger", "panic_handler"] }
-
-[patch.crates-io]
-#uefi = { path = "../uefi-rs/uefi" }
-uefi = { git = "https://github.com/rust-osdev/uefi-rs.git" }
-uefi-macros = { git = "https://github.com/rust-osdev/uefi-rs.git" }
-uefi-raw = { git = "https://github.com/rust-osdev/uefi-rs.git" }
+uefi = { version = "0.35", features = ["alloc", "global_allocator", "logger", "panic_handler"] }


### PR DESCRIPTION
Rather than using UEFI crates via github, update them to the relased version, 0.35.0